### PR TITLE
IOTEDGE-668 add quick install for sdk

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -98,7 +98,7 @@ The resources for installing the IEC SDK is in `/root/forgerock`. Follow the ins
 in the [Installation Guide](../docs/iec-installation-guide.md) to configure and install the IEC SDK.
 
 If you are already familiar with the installation process then you can quickly prepare a new environment by running
-the below command in the container:
+the following command in the container:
 
     quick_install
 

--- a/training/README.md
+++ b/training/README.md
@@ -96,3 +96,12 @@ The container has been set up with the following properties:
 
 The resources for installing the IEC SDK is in `/root/forgerock`. Follow the installation instructions
 in the [Installation Guide](../docs/iec-installation-guide.md) to configure and install the IEC SDK.
+
+If you are already familiar with the installation process then you can quickly prepare a new environment by running
+the below command in the container:
+
+    quick_install
+
+This command will perform all the instructions in the installation guide to unpack the IEC SDK and modify the
+configuration for the training environment. It will leave the environment in the same state as it would be in after
+manually performing the steps in the installation guide.

--- a/training/sdk/Dockerfile
+++ b/training/sdk/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update --yes && \
 # Add IEC resources
 WORKDIR /root/forgerock
 COPY resources/iec-sdk-linux-x86_64-lr-richos-*.tgz .
+ADD commands.sh /opt/forgerock/iec/commands.sh
+RUN chmod a+x /opt/forgerock/iec/commands.sh
+RUN /bin/bash -c "echo \"source /opt/forgerock/iec/commands.sh\" >> /root/.bashrc"
 
 # Set bash as the default command in the new container
 CMD ["bash"]

--- a/training/sdk/commands.sh
+++ b/training/sdk/commands.sh
@@ -31,9 +31,11 @@ function prepare_iec_sdk() {
 }
 
 #
-# Quick install will bring the gateway environment to the state
+# Quick install will bring the device environment to the state
 # it would be in after the installation guide has been completed
 #
 function quick_install() {
 	prepare_iec_sdk
+	export LD_LIBRARY_PATH=~/forgerock/lib
+	export DYLD_LIBRARY_PATH=~/forgerock/lib
 }

--- a/training/sdk/commands.sh
+++ b/training/sdk/commands.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#
+# Copyright 2019 ForgeRock AS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Environment variables
+export WORK_DIR="/root/forgerock"
+
+#
+# Unpack IEC SDK and modify configuration
+#
+function prepare_iec_sdk() {
+    echo "Preparing IEC SDK"
+    cd ${WORK_DIR}
+    tar -xzf iec-sdk-*.tgz
+    sed -i 's/127.0.0.1/172.16.0.11/g' sdk-config.json examples/*/*.c
+    cd - &>/dev/null
+}
+
+#
+# Quick install will bring the gateway environment to the state
+# it would be in after the installation guide has been completed
+#
+function quick_install() {
+	prepare_iec_sdk
+}


### PR DESCRIPTION
Unpacks the SDK and modifies the SDK configuration to work within the training environment. Addresses a pain point I had having to repeatedly modify the zmq endpoint in the static and dynamic configurations. 
 
There is definitely a discussion to be had about whether we should do this, and if so, then what should be included. E.g. should the LD_LIBRARY_PATH\DYLD_LIBRARY_PATH be set as well?